### PR TITLE
chore(deps): update SQLite from 3.45.2 to 3.45.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(SQLITE3_VERSION "3.45.2")
-set(SQLITE3_DOWNLOAD_URL "https://sqlite.org/2024/sqlite-amalgamation-3450200.zip")
-set(SQLITE3_SHA3_256 "8d9c553b52c7b1656a97fec7907cb00fd1419ac45104e45c76b7c2b81ffe0a9d")
+set(SQLITE3_VERSION "3.45.3")
+set(SQLITE3_DOWNLOAD_URL "https://sqlite.org/2024/sqlite-amalgamation-3450300.zip")
+set(SQLITE3_SHA3_256 "c514a2640102a43adb1ea17056df3e6772c3b5aea94e0e64d5c819156f540952")
 
 project(sqlite3 VERSION ${SQLITE3_VERSION} LANGUAGES C)
 


### PR DESCRIPTION
This PR updates SQLite from 3.45.2 to 3.45.3.

- [Download](https://sqlite.org/download.html)
- [Changelog](https://sqlite.org/changes.html)