### PR TITLE
chore(deps): update SQLite from 3.46.0 to 3.46.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(SQLITE3_VERSION "3.46.0")
-set(SQLITE3_DOWNLOAD_URL "https://sqlite.org/2024/sqlite-amalgamation-3460000.zip")
-set(SQLITE3_SHA3_256 "1221eed70de626871912bfca144c00411f0c30d3c2b7935cff3963b63370ef7c")
+set(SQLITE3_VERSION "3.46.1")
+set(SQLITE3_DOWNLOAD_URL "https://sqlite.org/2024/sqlite-amalgamation-3460100.zip")
+set(SQLITE3_SHA3_256 "af6aae8d3eccc608857c63cf56efbadc70da48b5c719446b353ed88dded1e288")
 
 project(sqlite3 VERSION ${SQLITE3_VERSION} LANGUAGES C)
 


### PR DESCRIPTION
This PR updates SQLite from 3.46.0 to 3.46.1.

- [Download](https://sqlite.org/download.html)
- [Changelog](https://sqlite.org/changes.html)