### PR TITLE
chore(deps): update SQLite from 3.50.2 to 3.52.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.17)
 
-set(SQLITE3_VERSION "3.50.2")
-set(SQLITE3_DOWNLOAD_URL "https://sqlite.org/2025/sqlite-amalgamation-3500200.zip")
-set(SQLITE3_SHA3_256 "75c118e727ee6a9a3d2c0e7c577500b0c16a848d109027f087b915b671f61f8a")
+set(SQLITE3_VERSION "3.52.0")
+set(SQLITE3_DOWNLOAD_URL "https://sqlite.org/2026/sqlite-amalgamation-3520000.zip")
+set(SQLITE3_SHA3_256 "3fab435106250ea1cdfd5f9fa1657ad832fd431df1d817d48af66ba166e0d16e")
 
 project(sqlite3 VERSION ${SQLITE3_VERSION} LANGUAGES C)
 


### PR DESCRIPTION
This PR updates SQLite from 3.50.2 to 3.52.0.

- [Download](https://sqlite.org/download.html)
- [Changelog](https://sqlite.org/changes.html)